### PR TITLE
Added touch support for touch supported browsers

### DIFF
--- a/app.css
+++ b/app.css
@@ -5,6 +5,9 @@ body {
 	-moz-user-select: none;
 	-o-user-select: none;
 	user-select: none;
+	overflow: hidden;
+	touch-action: none;
+	-ms-touch-action: none;
 }
 
 h4 {

--- a/app.js
+++ b/app.js
@@ -144,6 +144,44 @@ Droppable.prototype = {
 	}
 };
 
+
+function touchHandler(event)
+{
+    var touches = event.changedTouches,
+        first = touches[0],
+        type = "";
+    switch(event.type)
+    {
+        case "touchstart": type = "mousedown"; break;
+        case "touchmove":  type = "mousemove"; break;        
+        case "touchend":   type = "mouseup";   break;
+        default:           return;
+    }
+
+    // initMouseEvent(type, canBubble, cancelable, view, clickCount, 
+    //                screenX, screenY, clientX, clientY, ctrlKey, 
+    //                altKey, shiftKey, metaKey, button, relatedTarget);
+
+    var simulatedEvent = document.createEvent("MouseEvent");
+    simulatedEvent.initMouseEvent(type, true, true, window, 1, 
+                                  first.screenX, first.screenY, 
+                                  first.clientX, first.clientY, false, 
+                                  false, false, false, 0/*left*/, null);
+
+    first.target.dispatchEvent(simulatedEvent);
+    event.preventDefault();
+}
+
+function mapDocumentTouchToMouse() 
+{
+    document.addEventListener("touchstart", touchHandler, true);
+    document.addEventListener("touchmove", touchHandler, true);
+    document.addEventListener("touchend", touchHandler, true);
+    document.addEventListener("touchcancel", touchHandler, true);    
+}
+
+mapDocumentTouchToMouse();
+
 window.onload = function() {
 	var data = [
 		"These",


### PR DESCRIPTION
Added support for drag and drop using touch. Code taken from this section of stackoverflow:
http://stackoverflow.com/questions/1517924/javascript-mapping-touch-events-to-mouse-events

Browsers like opera and chrome support touchevents. These can also be enabled on firefox. By default on Edge and Firefox touch events are not enabled. Kindly allow the pull request.